### PR TITLE
Basic Windows input system implemented

### DIFF
--- a/src/application/application.cpp
+++ b/src/application/application.cpp
@@ -1,0 +1,30 @@
+#include "application.h"
+
+namespace App
+{
+  Application* InitApplication(int width, int height)
+  {
+    Application* app = (Application*)malloc(sizeof(Application));
+    app->isRunning = true;
+    app->bitmapInfo.bmiHeader.biSize = sizeof(app->bitmapInfo.bmiHeader);
+    app->bitmapInfo.bmiHeader.biPlanes = 1;
+    app->bitmapInfo.bmiHeader.biBitCount = 32;
+    app->bitmapInfo.bmiHeader.biCompression = BI_RGB;
+    app->bitmapInfo.bmiHeader.biWidth = width;
+    app->bitmapInfo.bmiHeader.biHeight = -height;
+
+    app->buffer.width = width;
+    app->buffer.height = height;
+    render::ResizeFramebuffer(&(app->buffer), width, height);
+    
+    for (int index = 0; index < 256; index++)
+    {
+      app->keyboard.keyState[index] = 0;
+    }
+
+    return app;
+  }
+
+  // Win32
+ 
+}

--- a/src/application/application.cpp
+++ b/src/application/application.cpp
@@ -15,7 +15,7 @@ namespace App
 
     app->buffer.width = width;
     app->buffer.height = height;
-    render::ResizeFramebuffer(&(app->buffer), width, height);
+    Render::ResizeFramebuffer(&(app->buffer), width, height);
     
     for (int index = 0; index < 256; index++)
     {

--- a/src/application/application.h
+++ b/src/application/application.h
@@ -9,10 +9,6 @@
 
 namespace App
 {
-  // TODO: Extract to module
-  // StateInfo (consider renaming to Application) defines application state.
-  // It is inteded for crossplatform usage, and will need to be extracted into its own header. 
-  // We can implement Win32 specific struct using preprocessor directives.
   struct Application
   {
     Input::Keyboard keyboard;

--- a/src/application/application.h
+++ b/src/application/application.h
@@ -1,0 +1,32 @@
+#ifndef __WEND_APPLICATION_H__
+#define __WEND_APPLICATION_H__
+
+#include <map>
+#include <windows.h>
+
+#include "../framebuffer/framebuffer.h"
+#include "../input/input.h"
+
+namespace App
+{
+  // TODO: Extract to module
+  // StateInfo (consider renaming to Application) defines application state.
+  // It is inteded for crossplatform usage, and will need to be extracted into its own header. 
+  // We can implement Win32 specific struct using preprocessor directives.
+  struct Application
+  {
+    Input::Keyboard keyboard;
+
+    // Rendering
+    render::Framebuffer buffer;
+    BITMAPINFO bitmapInfo;
+
+    // State
+    bool isRunning;
+  };
+
+  Application* InitApplication(int, int);
+}
+
+
+#endif //__WEND_APPLICATION_H__

--- a/src/application/application.h
+++ b/src/application/application.h
@@ -14,7 +14,7 @@ namespace App
     Input::Keyboard keyboard;
 
     // Rendering
-    render::Framebuffer buffer;
+    Render::Framebuffer buffer;
     BITMAPINFO bitmapInfo;
 
     // State

--- a/src/framebuffer/framebuffer.cpp
+++ b/src/framebuffer/framebuffer.cpp
@@ -1,8 +1,9 @@
-//#define WIN32
-#include "framebuffer.h"
-  #include <windows.h>
+#include <windows.h>
+#include <cstdint>
 
-namespace render
+#include "framebuffer.h"
+
+namespace Render
 {
   void ResizeFramebuffer(Framebuffer* buffer, int width, int height)
   {
@@ -18,5 +19,23 @@ namespace render
     int bitmapSize = (width * height) * bytesPerPixel;
     
     buffer->bitmap = VirtualAlloc(0, bitmapSize, MEM_COMMIT, PAGE_READWRITE);
+  }
+
+  void RenderGradient(Render::Framebuffer* buffer, int xOffset, int yOffset)
+  {
+    int pitch = buffer->width*4;
+    uint8_t* row = (uint8_t*)buffer->bitmap;
+    for(int y = 0; y < buffer->height; ++y)
+    {
+      uint32_t* pixel = (uint32_t*)row;
+      for(int x = 0; x < buffer->width; ++x)
+      {
+        *pixel = (uint8_t)(x+xOffset) << 16 | 
+                (uint8_t)(y+yOffset) << 8 | 
+                255;
+        ++pixel;
+      }
+      row += pitch;
+    }
   }
 }

--- a/src/framebuffer/framebuffer.h
+++ b/src/framebuffer/framebuffer.h
@@ -1,7 +1,7 @@
 #ifndef __WEND_FRAMEBUFFER_H__
 #define __WEND_FRAMEBUFFER_H__
 
-namespace render
+namespace Render
 {
   struct Framebuffer
   {
@@ -11,6 +11,7 @@ namespace render
   };
 
   void ResizeFramebuffer(Framebuffer*, int, int);
+  void RenderGradient(Render::Framebuffer* buffer, int xOffset, int yOffset);
 }
 
 #endif //__WEND_FRAMEBUFFER_H__

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -2,81 +2,32 @@
 
 namespace Input
 {
-  /* void SetKeyMap(std::map<size_t, uint8_t> keyMap)
+  bool CheckKeyIsPressed(uint8_t state)
   {
-    keyMap[0x00] = Key::NONE;
-
-    keyMap['A'] = Key::A; keyMap['B'] = Key::B; keyMap['C'] = Key::C; 
-    keyMap['D'] = Key::D; keyMap['E'] = Key::E; keyMap['F'] = Key::F;
-    keyMap['G'] = Key::G; keyMap['H'] = Key::H; keyMap['I'] = Key::I;
-    keyMap['J'] = Key::J; keyMap['K'] = Key::K; keyMap['L'] = Key::L;
-    keyMap['M'] = Key::M; keyMap['N'] = Key::N; keyMap['O'] = Key::O;
-    keyMap['P'] = Key::P; keyMap['Q'] = Key::Q; keyMap['R'] = Key::R;
-    keyMap['S'] = Key::S; keyMap['T'] = Key::T; keyMap['U'] = Key::U;
-    keyMap['V'] = Key::V; keyMap['W'] = Key::W; keyMap['X'] = Key::X;
-    keyMap['Y'] = Key::Y; keyMap['Z'] = Key::Z;
-
-    keyMap['0'] = Key::KP_0; keyMap['1'] = Key::KP_1;
-    keyMap['2'] = Key::KP_2; keyMap['3'] = Key::KP_3;
-    keyMap['4'] = Key::KP_4; keyMap['5'] = Key::KP_5;
-    keyMap['6'] = Key::KP_6; keyMap['7'] = Key::KP_7;
-    keyMap['8'] = Key::KP_8; keyMap['9'] = Key::KP_9;
-
-    keyMap[VK_NUMPAD0] = Key::NUM0; keyMap[VK_NUMPAD1] = Key::NUM1;
-    keyMap[VK_NUMPAD2] = Key::NUM2; keyMap[VK_NUMPAD3] = Key::NUM3;
-    keyMap[VK_NUMPAD4] = Key::NUM4; keyMap[VK_NUMPAD5] = Key::NUM5;
-    keyMap[VK_NUMPAD6] = Key::NUM6; keyMap[VK_NUMPAD7] = Key::NUM7;
-    keyMap[VK_NUMPAD8] = Key::NUM8; keyMap[VK_NUMPAD9] = Key::NUM9;
-
-    keyMap[VK_F1] = Key::F1;   keyMap[VK_F2] = Key::F2;
-    keyMap[VK_F3] = Key::F3;   keyMap[VK_F4] = Key::F4;
-    keyMap[VK_F5] = Key::F5;   keyMap[VK_F6] = Key::F6;
-    keyMap[VK_F7] = Key::F7;   keyMap[VK_F8] = Key::F8;
-    keyMap[VK_F9] = Key::F9;   keyMap[VK_F10] = Key::F10;
-    keyMap[VK_F11] = Key::F11; keyMap[VK_F12] = Key::F12;
-
-    keyMap[VK_MULTIPLY] = Key::MULT; keyMap[VK_ADD] = Key::PLUS; 
-    keyMap[VK_DIVIDE] = Key::DIVIDE;   keyMap[VK_SUBTRACT] = Key::MINUS; 
-    keyMap[VK_DECIMAL] = Key::DEC;
-
-    keyMap[VK_BACK] = Key::BACKSPACE; keyMap[VK_ESCAPE] = Key::ESCAPE; 
-    keyMap[VK_RETURN] = Key::ENTER; keyMap[VK_TAB] = Key::TAB; 
-    keyMap[VK_DELETE] - Key::DEL; keyMap[VK_HOME] = Key::HOME;
-		keyMap[VK_END] = Key::END; keyMap[VK_PRIOR] = Key::PAGEUP; 
-    keyMap[VK_NEXT] = Key::PAGEDOWN; keyMap[VK_INSERT] = Key::INS;
-    keyMap[VK_SHIFT] = Key::SHIFT; keyMap[VK_CONTROL] = Key::CTRL;
-		keyMap[VK_SPACE] = Key::SPACE;
-
-    keyMap[VK_OEM_1] = Key::COLON;
-		keyMap[VK_OEM_2] = Key::SLASH;
-		keyMap[VK_OEM_3] = Key::TILDE;
-		keyMap[VK_OEM_4] = Key::LBRACE;
-		keyMap[VK_OEM_5] = Key::BACKSLASH;
-		keyMap[VK_OEM_6] = Key::RBRACE;
-		keyMap[VK_OEM_7] = Key::QUOTE;
-		keyMap[VK_OEM_PLUS] = Key::EQUAL;
-		keyMap[VK_OEM_COMMA] = Key::COMMA;
-		keyMap[VK_OEM_MINUS] = Key::MINUS;
-		keyMap[VK_OEM_PERIOD] = Key::PERIOD;
-		keyMap[VK_CAPITAL] = Key::CAPSLOCK;
-  } */
-
-  void SetKeyState(uint8_t keyState[256], int32_t key, uint8_t state)
-  {
-    keyState[key] = state;
+    return (state & (1 << 0)) != 0;
   }
-
-  uint8_t GetKeyState(uint8_t* keyState, uint8_t key)
+  bool CheckKeyWasPressed(uint8_t state)
   {
-    return keyState[key];
+    return (state & (1 << 1)) != 0;
   }
-
-  bool CheckKeyIsDown(uint8_t state)
+  bool CheckKeyIsHeld(uint8_t state)
   {
-    return (state & (1 << 0));
+    return CheckKeyIsPressed(state) && CheckKeyWasPressed(state);
   }
-  bool CheckKeyWasDown(uint8_t state)
+  bool CheckKeyIsJustPressed(uint8_t state)
   {
-    return (state & (1 << 1));
+    return CheckKeyIsPressed(state) && !CheckKeyWasPressed(state);
+  }
+  bool CheckKeyIsReleased(uint8_t state)
+  {
+    return (state & (1 << 0)) == 0;
+  }
+  bool CheckKeyWasReleased(uint8_t state)
+  {
+    return (state & (1 << 1)) == 0;
+  }
+  bool CheckKeyIsJustReleased(uint8_t state)
+  {
+    return CheckKeyIsReleased(state) && !CheckKeyWasReleased(state);
   }
 }

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -1,0 +1,82 @@
+#include "input.h"
+
+namespace Input
+{
+  /* void SetKeyMap(std::map<size_t, uint8_t> keyMap)
+  {
+    keyMap[0x00] = Key::NONE;
+
+    keyMap['A'] = Key::A; keyMap['B'] = Key::B; keyMap['C'] = Key::C; 
+    keyMap['D'] = Key::D; keyMap['E'] = Key::E; keyMap['F'] = Key::F;
+    keyMap['G'] = Key::G; keyMap['H'] = Key::H; keyMap['I'] = Key::I;
+    keyMap['J'] = Key::J; keyMap['K'] = Key::K; keyMap['L'] = Key::L;
+    keyMap['M'] = Key::M; keyMap['N'] = Key::N; keyMap['O'] = Key::O;
+    keyMap['P'] = Key::P; keyMap['Q'] = Key::Q; keyMap['R'] = Key::R;
+    keyMap['S'] = Key::S; keyMap['T'] = Key::T; keyMap['U'] = Key::U;
+    keyMap['V'] = Key::V; keyMap['W'] = Key::W; keyMap['X'] = Key::X;
+    keyMap['Y'] = Key::Y; keyMap['Z'] = Key::Z;
+
+    keyMap['0'] = Key::KP_0; keyMap['1'] = Key::KP_1;
+    keyMap['2'] = Key::KP_2; keyMap['3'] = Key::KP_3;
+    keyMap['4'] = Key::KP_4; keyMap['5'] = Key::KP_5;
+    keyMap['6'] = Key::KP_6; keyMap['7'] = Key::KP_7;
+    keyMap['8'] = Key::KP_8; keyMap['9'] = Key::KP_9;
+
+    keyMap[VK_NUMPAD0] = Key::NUM0; keyMap[VK_NUMPAD1] = Key::NUM1;
+    keyMap[VK_NUMPAD2] = Key::NUM2; keyMap[VK_NUMPAD3] = Key::NUM3;
+    keyMap[VK_NUMPAD4] = Key::NUM4; keyMap[VK_NUMPAD5] = Key::NUM5;
+    keyMap[VK_NUMPAD6] = Key::NUM6; keyMap[VK_NUMPAD7] = Key::NUM7;
+    keyMap[VK_NUMPAD8] = Key::NUM8; keyMap[VK_NUMPAD9] = Key::NUM9;
+
+    keyMap[VK_F1] = Key::F1;   keyMap[VK_F2] = Key::F2;
+    keyMap[VK_F3] = Key::F3;   keyMap[VK_F4] = Key::F4;
+    keyMap[VK_F5] = Key::F5;   keyMap[VK_F6] = Key::F6;
+    keyMap[VK_F7] = Key::F7;   keyMap[VK_F8] = Key::F8;
+    keyMap[VK_F9] = Key::F9;   keyMap[VK_F10] = Key::F10;
+    keyMap[VK_F11] = Key::F11; keyMap[VK_F12] = Key::F12;
+
+    keyMap[VK_MULTIPLY] = Key::MULT; keyMap[VK_ADD] = Key::PLUS; 
+    keyMap[VK_DIVIDE] = Key::DIVIDE;   keyMap[VK_SUBTRACT] = Key::MINUS; 
+    keyMap[VK_DECIMAL] = Key::DEC;
+
+    keyMap[VK_BACK] = Key::BACKSPACE; keyMap[VK_ESCAPE] = Key::ESCAPE; 
+    keyMap[VK_RETURN] = Key::ENTER; keyMap[VK_TAB] = Key::TAB; 
+    keyMap[VK_DELETE] - Key::DEL; keyMap[VK_HOME] = Key::HOME;
+		keyMap[VK_END] = Key::END; keyMap[VK_PRIOR] = Key::PAGEUP; 
+    keyMap[VK_NEXT] = Key::PAGEDOWN; keyMap[VK_INSERT] = Key::INS;
+    keyMap[VK_SHIFT] = Key::SHIFT; keyMap[VK_CONTROL] = Key::CTRL;
+		keyMap[VK_SPACE] = Key::SPACE;
+
+    keyMap[VK_OEM_1] = Key::COLON;
+		keyMap[VK_OEM_2] = Key::SLASH;
+		keyMap[VK_OEM_3] = Key::TILDE;
+		keyMap[VK_OEM_4] = Key::LBRACE;
+		keyMap[VK_OEM_5] = Key::BACKSLASH;
+		keyMap[VK_OEM_6] = Key::RBRACE;
+		keyMap[VK_OEM_7] = Key::QUOTE;
+		keyMap[VK_OEM_PLUS] = Key::EQUAL;
+		keyMap[VK_OEM_COMMA] = Key::COMMA;
+		keyMap[VK_OEM_MINUS] = Key::MINUS;
+		keyMap[VK_OEM_PERIOD] = Key::PERIOD;
+		keyMap[VK_CAPITAL] = Key::CAPSLOCK;
+  } */
+
+  void SetKeyState(uint8_t keyState[256], int32_t key, uint8_t state)
+  {
+    keyState[key] = state;
+  }
+
+  uint8_t GetKeyState(uint8_t* keyState, uint8_t key)
+  {
+    return keyState[key];
+  }
+
+  bool CheckKeyIsDown(uint8_t state)
+  {
+    return (state & (1 << 0));
+  }
+  bool CheckKeyWasDown(uint8_t state)
+  {
+    return (state & (1 << 1));
+  }
+}

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -4,15 +4,11 @@ namespace Input
 {
   bool CheckKeyIsPressed(uint8_t state)
   {
-    return (state & (1 << 0)) != 0;
+    return (state & State::IS_PRESSED) != 0;
   }
   bool CheckKeyWasPressed(uint8_t state)
   {
-    return (state & (1 << 1)) != 0;
-  }
-  bool CheckKeyIsHeld(uint8_t state)
-  {
-    return CheckKeyIsPressed(state) && CheckKeyWasPressed(state);
+    return (state & State::WAS_PRESSED) != 0;
   }
   bool CheckKeyIsJustPressed(uint8_t state)
   {
@@ -20,14 +16,29 @@ namespace Input
   }
   bool CheckKeyIsReleased(uint8_t state)
   {
-    return (state & (1 << 0)) == 0;
+    return (state & State::IS_PRESSED) == 0;
   }
   bool CheckKeyWasReleased(uint8_t state)
   {
-    return (state & (1 << 1)) == 0;
+    return (state & State::WAS_PRESSED) == 0;
   }
   bool CheckKeyIsJustReleased(uint8_t state)
   {
     return CheckKeyIsReleased(state) && !CheckKeyWasReleased(state);
+  }
+
+  void PoolKeyState(uint8_t* keyState)
+  {
+    for (int keyIndex = 0; keyIndex < 256; keyIndex++)
+    {
+      if (Input::CheckKeyIsJustPressed(keyState[(Key)keyIndex]))
+      {
+        keyState[(Key)keyIndex] |= State::WAS_PRESSED;
+      }
+      else if (Input::CheckKeyIsJustReleased(keyState[(Key)keyIndex]))
+      {
+        keyState[(Key)keyIndex] &= ~(State::WAS_PRESSED);
+      }
+    }
   }
 }

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -219,6 +219,8 @@ namespace Input
   bool CheckKeyIsJustPressed(uint8_t);
   bool CheckKeyIsReleased(uint8_t);
   bool CheckKeyIsJustReleased(uint8_t);
+
+  void PoolKeyState(uint8_t*);
 }
 
 #endif //__WEND_INPUT_H__

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -5,6 +5,11 @@
 #include <map>
 #include <windows.h>
 
+enum State
+{
+  IS_PRESSED = (1 << 0),
+  WAS_PRESSED = (1 << 1), 
+};
 
 enum Key
 {
@@ -16,49 +21,45 @@ enum Key
   SPACE     = 0x03,
   BACKSPACE = 0x04,
   TAB       = 0x05,
-  CAPSLOCK  = 0x06,
-  SHIFT     = 0x07,
-  CTRL      = 0x08,
-  ALT       = 0x09,
-  HOME      = 0x0A,
-  END       = 0x0B,
-  PAGEUP    = 0x0C,
-  PAGEDOWN  = 0x0D,
-  DEL       = 0x0E,
-  INS       = 0x0F,
-
+  HOME      = 0x06,
+  END       = 0x07,
+  PAGEUP    = 0x08,
+  PAGEDOWN  = 0x09,
+  DEL       = 0x0A,
+  INS       = 0x0B,
+  PAUSE     = 0x0C,
+  CAPSLOCK  = 0x0D,
+  NUMLOCK   = 0x0E,
+  SCROLL    = 0x0F,
+  SUPER     = 0x10, // WINDOWS key
+  MENU      = 0x11, // APPS key
+  CLEAR     = 0x14,
+  SHIFT     = 0x15,
+  CTRL      = 0x16,
+  ALT       = 0x17, // MENU key
+  UP        = 0x18,
+  DOWN      = 0x19,
+  LEFT      = 0x1A,
+  RIGHT     = 0x1B,
+ 
   // Operator Keys
-  MULT      = 0x10,
-  PLUS      = 0x11,
-  MINUS     = 0x12,
-  DIVIDE    = 0x13,
-  DEC       = 0x14,
-  HYPHEN    = 0x15,
-  EQUAL     = 0x16,
-  LBRACE    = 0x17,
-  RBRACE    = 0x18,
-  SLASH     = 0x19,
-  BACKSLASH = 0x1A,
-  COLON     = 0x1B,
-  QUOTE     = 0x1C,
-  COMMA     = 0x1D,
-  PERIOD    = 0x1E,
-  TILDE     = 0x1F,
+  MULT      = 0x20,
+  PLUS      = 0x21,
+  MINUS     = 0x22,
+  DIVIDE    = 0x23,
+  DECM      = 0x24,
+  HYPHEN    = 0x25,
+  EQUAL     = 0x26,
+  LBRACE    = 0x27,
+  RBRACE    = 0x28,
+  SLASH     = 0x29,
+  BACKSLASH = 0x2A,
+  COLON     = 0x2B,
+  QUOTE     = 0x2C,
+  COMMA     = 0x2D,
+  PERIOD    = 0x2E,
+  TILDE     = 0x2F,
 
-  // Function Keys
-  F1  = 0x21,
-  F2  = 0x22,
-  F3  = 0x23,
-  F4  = 0x24,
-  F5  = 0x25,
-  F6  = 0x26,
-  F7  = 0x27,
-  F8  = 0x28,
-  F9  = 0x29,
-  F10 = 0x2A,
-  F11 = 0x2B,
-  F12 = 0x2C,
-  
   // Numeric Keys (Match ANSI)
   KP_0 = 0x30,
   KP_1 = 0x31,
@@ -99,6 +100,7 @@ enum Key
   Y = 0x59,
   Z = 0x5A,
 
+  // Numpad Keys
   NUM0 = 0x60,
   NUM1 = 0x61,
   NUM2 = 0x62,
@@ -109,9 +111,43 @@ enum Key
   NUM7 = 0x67,
   NUM8 = 0x68,
   NUM9 = 0x69,
+  
+  // Function Keys
+  F1  = 0x71,
+  F2  = 0x72,
+  F3  = 0x73,
+  F4  = 0x74,
+  F5  = 0x75,
+  F6  = 0x76,
+  F7  = 0x77,
+  F8  = 0x78,
+  F9  = 0x79,
+  F10 = 0x7A,
+  F11 = 0x7B,
+  F12 = 0x7C,
+  F13 = 0x7D,
+  F14 = 0x7E,
+  F15 = 0x7F,
+  F16 = 0x80,
+  F17 = 0x81,
+  F18 = 0x82,
+  F19 = 0x83,
+  F20 = 0x84,
+  F21 = 0x85,
+  F22 = 0x86,
+  F23 = 0x87,
+  F24 = 0x88,
 };
 
-static const std::map<size_t, Key> keyMap = {
+namespace Input
+{
+
+  struct Keyboard
+  {
+    uint8_t keyState[256];
+    // creates a hashmap pairing between virtual key and custom keycode. 
+    // cross-platform function
+    static const inline std::map<size_t, Key> keyMap = {
       {0x00, Key::NONE}, 
       
       {'A', Key::A}, {'B', Key::B}, {'C', Key::C}, 
@@ -142,10 +178,16 @@ static const std::map<size_t, Key> keyMap = {
       {VK_F7, Key::F7},   {VK_F8, Key::F8},
       {VK_F9, Key::F9},   {VK_F10, Key::F10},
       {VK_F11, Key::F11}, {VK_F12, Key::F12},
+      {VK_F11, Key::F13}, {VK_F12, Key::F14},
+      {VK_F11, Key::F15}, {VK_F12, Key::F16},
+      {VK_F11, Key::F17}, {VK_F12, Key::F18},
+      {VK_F11, Key::F19}, {VK_F12, Key::F20},
+      {VK_F11, Key::F21}, {VK_F12, Key::F22},
+      {VK_F11, Key::F23}, {VK_F12, Key::F24},
 
       {VK_MULTIPLY, Key::MULT}, {VK_ADD, Key::PLUS}, 
       {VK_DIVIDE, Key::DIVIDE}, {VK_SUBTRACT, Key::MINUS}, 
-      {VK_DECIMAL, Key::DEC},
+      {VK_DECIMAL, Key::DECM},
 
       {VK_BACK, Key::BACKSPACE}, {VK_ESCAPE, Key::ESCAPE}, 
       {VK_RETURN, Key::ENTER},   {VK_TAB, Key::TAB}, 
@@ -153,7 +195,11 @@ static const std::map<size_t, Key> keyMap = {
       {VK_END, Key::END},        {VK_PRIOR, Key::PAGEUP}, 
       {VK_NEXT, Key::PAGEDOWN},  {VK_INSERT, Key::INS},
       {VK_SHIFT, Key::SHIFT},    {VK_CONTROL, Key::CTRL},
-      {VK_SPACE, Key::SPACE},
+      {VK_SPACE, Key::SPACE},    {VK_NUMLOCK, Key::NUMLOCK},
+      {VK_PAUSE, Key::PAUSE},    {VK_CAPITAL, Key::CAPSLOCK},
+      {VK_SCROLL, Key::SCROLL},  {VK_MENU, Key::ALT},
+      {VK_LWIN, Key::SUPER},     {VK_RWIN, Key::SUPER},
+      {VK_APPS, Key::MENU},
 
       {VK_OEM_1, Key::COLON},       {VK_OEM_2, Key::SLASH},
       {VK_OEM_3, Key::TILDE},       {VK_OEM_4, Key::LBRACE},
@@ -161,24 +207,18 @@ static const std::map<size_t, Key> keyMap = {
       {VK_OEM_7, Key::QUOTE},       {VK_OEM_PLUS, Key::EQUAL},
       {VK_OEM_COMMA, Key::COMMA},   {VK_OEM_MINUS, Key::MINUS},
       {VK_OEM_PERIOD, Key::PERIOD}, {VK_CAPITAL, Key::CAPSLOCK},
-};
 
-namespace Input
-{
-
-  struct Keyboard
-  {
-    // creates a hashmap pairing between virtual key and custom keycode. 
-    // cross-platform function
-    
-    uint8_t keyState[256];
+      {VK_UP, Key::UP},     {VK_DOWN, Key::DOWN}, 
+      {VK_LEFT, Key::LEFT}, {VK_RIGHT, Key::RIGHT},
+    };
   };
 
-  /* void SetKeyMap(std::map<size_t, uint8_t>); */
-  void SetKeyState(uint8_t[256], int32_t, uint8_t);
-  uint8_t GetKeyState(uint8_t*, uint8_t);
-  bool CheckKeyIsDown(uint8_t);
-  bool CheckKeyWasDown(uint8_t);
+  bool CheckKeyIsPressed(uint8_t);
+  bool CheckKeyWasPressed(uint8_t);
+  bool CheckKeyIsHeld(uint8_t);
+  bool CheckKeyIsJustPressed(uint8_t);
+  bool CheckKeyIsReleased(uint8_t);
+  bool CheckKeyIsJustReleased(uint8_t);
 }
 
 #endif //__WEND_INPUT_H__

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -1,0 +1,184 @@
+#ifndef __WEND_INPUT_H__
+#define __WEND_INPUT_H__
+
+#include <cstdint>
+#include <map>
+#include <windows.h>
+
+
+enum Key
+{
+  NONE = 0x00,
+
+  // Command keys
+  ESCAPE    = 0x01,
+  ENTER     = 0x02,
+  SPACE     = 0x03,
+  BACKSPACE = 0x04,
+  TAB       = 0x05,
+  CAPSLOCK  = 0x06,
+  SHIFT     = 0x07,
+  CTRL      = 0x08,
+  ALT       = 0x09,
+  HOME      = 0x0A,
+  END       = 0x0B,
+  PAGEUP    = 0x0C,
+  PAGEDOWN  = 0x0D,
+  DEL       = 0x0E,
+  INS       = 0x0F,
+
+  // Operator Keys
+  MULT      = 0x10,
+  PLUS      = 0x11,
+  MINUS     = 0x12,
+  DIVIDE    = 0x13,
+  DEC       = 0x14,
+  HYPHEN    = 0x15,
+  EQUAL     = 0x16,
+  LBRACE    = 0x17,
+  RBRACE    = 0x18,
+  SLASH     = 0x19,
+  BACKSLASH = 0x1A,
+  COLON     = 0x1B,
+  QUOTE     = 0x1C,
+  COMMA     = 0x1D,
+  PERIOD    = 0x1E,
+  TILDE     = 0x1F,
+
+  // Function Keys
+  F1  = 0x21,
+  F2  = 0x22,
+  F3  = 0x23,
+  F4  = 0x24,
+  F5  = 0x25,
+  F6  = 0x26,
+  F7  = 0x27,
+  F8  = 0x28,
+  F9  = 0x29,
+  F10 = 0x2A,
+  F11 = 0x2B,
+  F12 = 0x2C,
+  
+  // Numeric Keys (Match ANSI)
+  KP_0 = 0x30,
+  KP_1 = 0x31,
+  KP_2 = 0x32,
+  KP_3 = 0x33,
+  KP_4 = 0x34,
+  KP_5 = 0x35,
+  KP_6 = 0x36,
+  KP_7 = 0x37,
+  KP_8 = 0x38,
+  KP_9 = 0x39,
+
+  // Alpha keys (Match ANSI)
+  A = 0x41,
+  B = 0x42,
+  C = 0x43,
+  D = 0x44,
+  E = 0x45,
+  F = 0x46,
+  G = 0x47,
+  H = 0x48,
+  I = 0x49,
+  J = 0x4A,
+  K = 0x4B,
+  L = 0x4C,
+  M = 0x4D,
+  N = 0x4E,
+  O = 0x4F,
+  P = 0x50,
+  Q = 0x51,
+  R = 0x52,
+  S = 0x53,
+  T = 0x54,
+  U = 0x55,
+  V = 0x56,
+  W = 0x57,
+  X = 0x58,
+  Y = 0x59,
+  Z = 0x5A,
+
+  NUM0 = 0x60,
+  NUM1 = 0x61,
+  NUM2 = 0x62,
+  NUM3 = 0x63,
+  NUM4 = 0x64,
+  NUM5 = 0x65,
+  NUM6 = 0x66,
+  NUM7 = 0x67,
+  NUM8 = 0x68,
+  NUM9 = 0x69,
+};
+
+static const std::map<size_t, Key> keyMap = {
+      {0x00, Key::NONE}, 
+      
+      {'A', Key::A}, {'B', Key::B}, {'C', Key::C}, 
+      {'D', Key::D}, {'E', Key::E}, {'F', Key::F},
+      {'G', Key::G}, {'H', Key::H}, {'I', Key::I},
+      {'J', Key::J}, {'K', Key::K}, {'L', Key::L},
+      {'M', Key::M}, {'N', Key::N}, {'O', Key::O},
+      {'P', Key::P}, {'Q', Key::Q}, {'R', Key::R},
+      {'S', Key::S}, {'T', Key::T}, {'U', Key::U},
+      {'V', Key::V}, {'W', Key::W}, {'X', Key::X},
+      {'Y', Key::Y}, {'Z', Key::Z},
+
+      {'0', Key::KP_0}, {'1', Key::KP_1},
+      {'2', Key::KP_2}, {'3', Key::KP_3},
+      {'4', Key::KP_4}, {'5', Key::KP_5},
+      {'6', Key::KP_6}, {'7', Key::KP_7},
+      {'8', Key::KP_8}, {'9', Key::KP_9},
+
+      {VK_NUMPAD0, Key::NUM0}, {VK_NUMPAD1, Key::NUM1},
+      {VK_NUMPAD2, Key::NUM2}, {VK_NUMPAD3, Key::NUM3},
+      {VK_NUMPAD4, Key::NUM4}, {VK_NUMPAD5, Key::NUM5},
+      {VK_NUMPAD6, Key::NUM6}, {VK_NUMPAD7, Key::NUM7},
+      {VK_NUMPAD8, Key::NUM8}, {VK_NUMPAD9, Key::NUM9},
+
+      {VK_F1, Key::F1},   {VK_F2, Key::F2},
+      {VK_F3, Key::F3},   {VK_F4, Key::F4},
+      {VK_F5, Key::F5},   {VK_F6, Key::F6},
+      {VK_F7, Key::F7},   {VK_F8, Key::F8},
+      {VK_F9, Key::F9},   {VK_F10, Key::F10},
+      {VK_F11, Key::F11}, {VK_F12, Key::F12},
+
+      {VK_MULTIPLY, Key::MULT}, {VK_ADD, Key::PLUS}, 
+      {VK_DIVIDE, Key::DIVIDE}, {VK_SUBTRACT, Key::MINUS}, 
+      {VK_DECIMAL, Key::DEC},
+
+      {VK_BACK, Key::BACKSPACE}, {VK_ESCAPE, Key::ESCAPE}, 
+      {VK_RETURN, Key::ENTER},   {VK_TAB, Key::TAB}, 
+      {VK_DELETE, Key::DEL},     {VK_HOME, Key::HOME},
+      {VK_END, Key::END},        {VK_PRIOR, Key::PAGEUP}, 
+      {VK_NEXT, Key::PAGEDOWN},  {VK_INSERT, Key::INS},
+      {VK_SHIFT, Key::SHIFT},    {VK_CONTROL, Key::CTRL},
+      {VK_SPACE, Key::SPACE},
+
+      {VK_OEM_1, Key::COLON},       {VK_OEM_2, Key::SLASH},
+      {VK_OEM_3, Key::TILDE},       {VK_OEM_4, Key::LBRACE},
+      {VK_OEM_5, Key::BACKSLASH},   {VK_OEM_6, Key::RBRACE},
+      {VK_OEM_7, Key::QUOTE},       {VK_OEM_PLUS, Key::EQUAL},
+      {VK_OEM_COMMA, Key::COMMA},   {VK_OEM_MINUS, Key::MINUS},
+      {VK_OEM_PERIOD, Key::PERIOD}, {VK_CAPITAL, Key::CAPSLOCK},
+};
+
+namespace Input
+{
+
+  struct Keyboard
+  {
+    // creates a hashmap pairing between virtual key and custom keycode. 
+    // cross-platform function
+    
+    uint8_t keyState[256];
+  };
+
+  /* void SetKeyMap(std::map<size_t, uint8_t>); */
+  void SetKeyState(uint8_t[256], int32_t, uint8_t);
+  uint8_t GetKeyState(uint8_t*, uint8_t);
+  bool CheckKeyIsDown(uint8_t);
+  bool CheckKeyWasDown(uint8_t);
+}
+
+#endif //__WEND_INPUT_H__

--- a/src/win_main.cpp
+++ b/src/win_main.cpp
@@ -104,19 +104,23 @@ int WINAPI WinMain(HINSTANCE instance,
     uint8_t* keyState = app->keyboard.keyState;
     Input::PoolKeyState(keyState);
 
-    if (Input::CheckKeyIsPressed(keyState[Key::W]))
+    if (Input::CheckKeyIsPressed(keyState[Key::W]) ||
+        Input::CheckKeyIsPressed(keyState[Key::UP]))
     {
       yOffset++;
     }
-    if (Input::CheckKeyIsPressed(keyState[Key::S]))
+    if (Input::CheckKeyIsPressed(keyState[Key::S]) ||
+        Input::CheckKeyIsPressed(keyState[Key::DOWN]))
     {
       yOffset--;
     }
-    if (Input::CheckKeyIsPressed(keyState[Key::A]))
+    if (Input::CheckKeyIsPressed(keyState[Key::A]) ||
+        Input::CheckKeyIsPressed(keyState[Key::LEFT]))
     {
       xOffset++;
     }
-    if (Input::CheckKeyIsPressed(keyState[Key::D]))
+    if (Input::CheckKeyIsPressed(keyState[Key::D]) ||
+        Input::CheckKeyIsPressed(keyState[Key::RIGHT]))
     {
       xOffset--;
     }

--- a/src/win_main.cpp
+++ b/src/win_main.cpp
@@ -102,6 +102,24 @@ int WINAPI WinMain(HINSTANCE instance,
     }
     
     uint8_t* keyState = app->keyboard.keyState;
+    Input::PoolKeyState(keyState);
+
+    if (Input::CheckKeyIsPressed(keyState[Key::W]))
+    {
+      yOffset++;
+    }
+    if (Input::CheckKeyIsPressed(keyState[Key::S]))
+    {
+      yOffset--;
+    }
+    if (Input::CheckKeyIsPressed(keyState[Key::A]))
+    {
+      xOffset++;
+    }
+    if (Input::CheckKeyIsPressed(keyState[Key::D]))
+    {
+      xOffset--;
+    }
 
     Render::RenderGradient(&(app->buffer), xOffset, yOffset);
     

--- a/src/win_main.cpp
+++ b/src/win_main.cpp
@@ -183,13 +183,6 @@ LRESULT CALLBACK WindowProc(HWND window,
       uint8_t* keyState =  appState->keyboard.keyState;
       const std::map<size_t, Key> map = appState->keyboard.keyMap;
 
-      // Prevents out of bounds access in map
-      // Therefore, only registered keys are usable in map
-      if (map.find(wParam) == map.end())
-      {
-        return 0;
-      }
-
       if (wParam == VK_ESCAPE)
       {
         if (MessageBoxA(window, "Are you sure you want to quit? Unsaved progress will be lost.", "Wend", MB_OKCANCEL) == IDOK)
@@ -198,6 +191,12 @@ LRESULT CALLBACK WindowProc(HWND window,
         }
       }
 
+      // Prevents out of bounds access in map
+      // Therefore, only registered keys are usable in map
+      if (map.find(wParam) == map.end())
+      {
+        return 0;
+      }
 
       if ((lParam & (1 << 31)) == 0) 
       {


### PR DESCRIPTION
Using Windows message system, implemented input logging for all keys on standard US keyboards.
Keys use bitfields to track their state. Bit 0 tracks "is pressed", Bit 1 tracks "was pressed". Other states like "is just pressed" or "is released" can be derived from these two states.
Separated application state management into its own header.
Everything is still Windows specific for the time being.