### PR TITLE
Add XInput API for gamepad inputs

### DIFF
--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -41,4 +41,26 @@ namespace Input
       }
     }
   }
+  
+  void InitXInput(fn_XInputGetState** XInputGetState, fn_XInputSetState** XInputSetState)
+  {
+    // Get library
+    HMODULE xInputLibrary = LoadLibraryA("xinput1_3.dll");
+    if (!xInputLibrary)
+    {
+      return;
+    }
+
+    // Link function call to library
+    *XInputGetState = (fn_XInputGetState *)GetProcAddress(xInputLibrary, "XInputGetState");
+    if (!XInputGetState)
+    {
+      return;
+    }
+    *XInputSetState = (fn_XInputSetState *)GetProcAddress(xInputLibrary, "XInputSetState");
+    if (!XInputSetState)
+    {
+      return;
+    }
+  }
 }

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -8,17 +8,9 @@
 
 #define XINPUT_GET_STATE(name) DWORD WINAPI name(DWORD dwUserIndex, XINPUT_STATE* pState)
 typedef XINPUT_GET_STATE(fn_XInputGetState);
-/* XINPUT_GET_STATE(XInputGetStateStub)
-{
-  return 0;
-} */
 
 #define XINPUT_SET_STATE(name) DWORD WINAPI name(DWORD dwUserIndex, XINPUT_VIBRATION* pVibration)
 typedef XINPUT_SET_STATE(fn_XInputSetState);
-/* XINPUT_SET_STATE(XInputSetStateStub)
-{
-  return 0;
-} */
 
 enum State
 {
@@ -160,6 +152,7 @@ namespace Input
   struct Keyboard
   {
     uint8_t keyState[256];
+    
     // creates a hashmap pairing between virtual key and custom keycode. 
     // cross-platform function
     static const inline std::map<size_t, Key> keyMap = {

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -4,6 +4,21 @@
 #include <cstdint>
 #include <map>
 #include <windows.h>
+#include <xinput.h>
+
+#define XINPUT_GET_STATE(name) DWORD WINAPI name(DWORD dwUserIndex, XINPUT_STATE* pState)
+typedef XINPUT_GET_STATE(fn_XInputGetState);
+/* XINPUT_GET_STATE(XInputGetStateStub)
+{
+  return 0;
+} */
+
+#define XINPUT_SET_STATE(name) DWORD WINAPI name(DWORD dwUserIndex, XINPUT_VIBRATION* pVibration)
+typedef XINPUT_SET_STATE(fn_XInputSetState);
+/* XINPUT_SET_STATE(XInputSetStateStub)
+{
+  return 0;
+} */
 
 enum State
 {
@@ -221,6 +236,8 @@ namespace Input
   bool CheckKeyIsJustReleased(uint8_t);
 
   void PoolKeyState(uint8_t*);
+
+  void InitXInput(fn_XInputGetState**, fn_XInputSetState**);
 }
 
 #endif //__WEND_INPUT_H__

--- a/src/win_main.cpp
+++ b/src/win_main.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstdbool>
+#include <xinput.h>
 
 #include "framebuffer/framebuffer.h"
 #include "application/application.h"
@@ -103,6 +104,14 @@ int WINAPI WinMain(HINSTANCE instance,
   Audio::FillBuffer(soundBuffer, &audioCfg, 0, audioCfg.bufferSize);
   soundBuffer->Play(0, 0, DSBPLAY_LOOPING);
 
+  fn_XInputGetState* XInputGetState = nullptr;
+  fn_XInputSetState* XInputSetState = nullptr;
+  Input::InitXInput(&XInputGetState, &XInputSetState);
+  if (!XInputGetState || !XInputSetState)
+  {
+    // ERROR: No XInput DLL
+  }
+
   ShowWindow(window, cmdShow);
   UpdateWindow(window);
 
@@ -115,6 +124,56 @@ int WINAPI WinMain(HINSTANCE instance,
     {
       TranslateMessage(&message);
       DispatchMessage(&message);
+    }
+
+    for(int controllerIndex = 0; 
+        controllerIndex < XUSER_MAX_COUNT; 
+        controllerIndex++)
+    {
+
+      XINPUT_STATE controllerState;
+      if (XInputGetState(controllerIndex, &controllerState) == ERROR_SUCCESS)
+      {
+        XINPUT_GAMEPAD* gamepad = &controllerState.Gamepad;
+
+        bool dpadUp = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_UP;
+        bool dpadDown = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_DOWN;
+        bool dpadLeft = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_LEFT;
+        bool dpadRight = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_RIGHT;
+        bool faceBottom = gamepad->wButtons & XINPUT_GAMEPAD_A;
+        bool faceRight = gamepad->wButtons & XINPUT_GAMEPAD_B;
+        bool faceLeft = gamepad->wButtons & XINPUT_GAMEPAD_X;
+        bool faceTop = gamepad->wButtons & XINPUT_GAMEPAD_Y;
+        bool shoulderLeft = gamepad->wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER;
+        bool shoulderRight = gamepad->wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER;
+        bool thumbstickLeft = gamepad->wButtons & XINPUT_GAMEPAD_LEFT_THUMB;
+        bool thumbstickRight = gamepad->wButtons & XINPUT_GAMEPAD_RIGHT_THUMB;
+        bool start = gamepad->wButtons & XINPUT_GAMEPAD_START;
+        bool select = gamepad->wButtons & XINPUT_GAMEPAD_BACK;
+
+        int8_t triggerLeft = gamepad->bLeftTrigger;
+        int8_t triggerRight = gamepad->bRightTrigger;
+
+        int16_t xAxisLeft = gamepad->sThumbLX;
+        int16_t yAxisLeft = gamepad->sThumbLY;
+        
+        int16_t xAxisRight = gamepad->sThumbRX;
+        int16_t yAxisRight = gamepad->sThumbRY;
+
+        int16_t deadzone = 2000;
+        if (abs(xAxisLeft) > deadzone)
+        {          
+          xOffset -= (xAxisLeft >> 12);
+        }
+        if (abs(yAxisLeft) > deadzone)
+        {          
+          yOffset += (yAxisLeft >> 12);
+        }
+      }
+      else
+      {
+        continue;
+      }
     }
     
     uint8_t* keyState = app->keyboard.keyState;

--- a/src/win_main.cpp
+++ b/src/win_main.cpp
@@ -109,7 +109,7 @@ int WINAPI WinMain(HINSTANCE instance,
   Input::InitXInput(&XInputGetState, &XInputSetState);
   if (!XInputGetState || !XInputSetState)
   {
-    // ERROR: No XInput DLL
+    // TODO: Log xinput dll not found
   }
 
   ShowWindow(window, cmdShow);
@@ -126,53 +126,56 @@ int WINAPI WinMain(HINSTANCE instance,
       DispatchMessage(&message);
     }
 
-    for(int controllerIndex = 0; 
-        controllerIndex < XUSER_MAX_COUNT; 
-        controllerIndex++)
+    // Only attempt to read controller information if XInput is loaded
+    if (XInputGetState) 
     {
-
-      XINPUT_STATE controllerState;
-      if (XInputGetState(controllerIndex, &controllerState) == ERROR_SUCCESS)
+      for(int controllerIndex = 0; 
+          controllerIndex < XUSER_MAX_COUNT; 
+          controllerIndex++)
       {
-        XINPUT_GAMEPAD* gamepad = &controllerState.Gamepad;
+        XINPUT_STATE controllerState;
+        if (XInputGetState(controllerIndex, &controllerState) == ERROR_SUCCESS)
+        {
+          XINPUT_GAMEPAD* gamepad = &controllerState.Gamepad;
 
-        bool dpadUp = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_UP;
-        bool dpadDown = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_DOWN;
-        bool dpadLeft = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_LEFT;
-        bool dpadRight = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_RIGHT;
-        bool faceBottom = gamepad->wButtons & XINPUT_GAMEPAD_A;
-        bool faceRight = gamepad->wButtons & XINPUT_GAMEPAD_B;
-        bool faceLeft = gamepad->wButtons & XINPUT_GAMEPAD_X;
-        bool faceTop = gamepad->wButtons & XINPUT_GAMEPAD_Y;
-        bool shoulderLeft = gamepad->wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER;
-        bool shoulderRight = gamepad->wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER;
-        bool thumbstickLeft = gamepad->wButtons & XINPUT_GAMEPAD_LEFT_THUMB;
-        bool thumbstickRight = gamepad->wButtons & XINPUT_GAMEPAD_RIGHT_THUMB;
-        bool start = gamepad->wButtons & XINPUT_GAMEPAD_START;
-        bool select = gamepad->wButtons & XINPUT_GAMEPAD_BACK;
+          bool dpadUp = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_UP;
+          bool dpadDown = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_DOWN;
+          bool dpadLeft = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_LEFT;
+          bool dpadRight = gamepad->wButtons & XINPUT_GAMEPAD_DPAD_RIGHT;
+          bool faceBottom = gamepad->wButtons & XINPUT_GAMEPAD_A;
+          bool faceRight = gamepad->wButtons & XINPUT_GAMEPAD_B;
+          bool faceLeft = gamepad->wButtons & XINPUT_GAMEPAD_X;
+          bool faceTop = gamepad->wButtons & XINPUT_GAMEPAD_Y;
+          bool shoulderLeft = gamepad->wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER;
+          bool shoulderRight = gamepad->wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER;
+          bool thumbstickLeft = gamepad->wButtons & XINPUT_GAMEPAD_LEFT_THUMB;
+          bool thumbstickRight = gamepad->wButtons & XINPUT_GAMEPAD_RIGHT_THUMB;
+          bool start = gamepad->wButtons & XINPUT_GAMEPAD_START;
+          bool select = gamepad->wButtons & XINPUT_GAMEPAD_BACK;
 
-        int8_t triggerLeft = gamepad->bLeftTrigger;
-        int8_t triggerRight = gamepad->bRightTrigger;
+          int8_t triggerLeft = gamepad->bLeftTrigger;
+          int8_t triggerRight = gamepad->bRightTrigger;
 
-        int16_t xAxisLeft = gamepad->sThumbLX;
-        int16_t yAxisLeft = gamepad->sThumbLY;
-        
-        int16_t xAxisRight = gamepad->sThumbRX;
-        int16_t yAxisRight = gamepad->sThumbRY;
+          int16_t xAxisLeft = gamepad->sThumbLX;
+          int16_t yAxisLeft = gamepad->sThumbLY;
+          
+          int16_t xAxisRight = gamepad->sThumbRX;
+          int16_t yAxisRight = gamepad->sThumbRY;
 
-        int16_t deadzone = 2000;
-        if (abs(xAxisLeft) > deadzone)
-        {          
-          xOffset -= (xAxisLeft >> 12);
+          int16_t deadzone = 2000;
+          if (abs(xAxisLeft) > deadzone)
+          {          
+            xOffset -= (xAxisLeft >> 12);
+          }
+          if (abs(yAxisLeft) > deadzone)
+          {          
+            yOffset += (yAxisLeft >> 12);
+          }
         }
-        if (abs(yAxisLeft) > deadzone)
-        {          
-          yOffset += (yAxisLeft >> 12);
+        else
+        {
+          continue;
         }
-      }
-      else
-      {
-        continue;
       }
     }
     
@@ -246,7 +249,10 @@ LRESULT CALLBACK WindowProc(HWND window,
 
     case WM_CLOSE:
     {
-      if (MessageBoxA(window, "Are you sure you want to quit? Unsaved progress will be lost.", "Wend", MB_OKCANCEL) == IDOK)
+      if (MessageBoxA(window, 
+                      "Are you sure you want to quit? Unsaved progress will be lost.", 
+                      "Wend", 
+                      MB_OKCANCEL) == IDOK)
       {
         DestroyWindow(window);
       }
@@ -283,7 +289,10 @@ LRESULT CALLBACK WindowProc(HWND window,
 
       if (wParam == VK_ESCAPE)
       {
-        if (MessageBoxA(window, "Are you sure you want to quit? Unsaved progress will be lost.", "Wend", MB_OKCANCEL) == IDOK)
+        if (MessageBoxA(window, 
+                        "Are you sure you want to quit? Unsaved progress will be lost.", 
+                        "Wend", 
+                        MB_OKCANCEL) == IDOK)
         {
           DestroyWindow(window);
         }


### PR DESCRIPTION
- Attempts to load XInput from the user's device
  - If XInput fails to load, does not attempt to retrieve device information
  - If successful, reads controller data each frame
- Directional inputs used to test